### PR TITLE
fix(eval): bind JSONB param when inserting into metrics

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,65 +1,82 @@
 # mypy: ignore-errors
+
+"""Alembic environment configuration for async SQLAlchemy."""
+
 from __future__ import annotations
+
 import asyncio
+import os
 from logging.config import fileConfig
+from typing import Any, Dict
 
 from alembic import context
-from sqlalchemy import pool
-from sqlalchemy.engine import Connection
-from sqlalchemy.ext.asyncio import async_engine_from_config
+from sqlalchemy.ext.asyncio import async_engine_from_config, AsyncEngine
 
-# Import app settings and metadata
-from pkmn_factors.config import settings
-from pkmn_factors.db.base import Base
-from pkmn_factors.db import models  # noqa: F401  (populate metadata)
+# --- Your app imports (must be importable) ---
+# IMPORTANT: Base is declared in pkmn_factors.db.models
+from pkmn_factors.db.models import Base  # SQLAlchemy declarative Base
+from pkmn_factors.config import settings  # reads DATABASE_URL from env
 
-# Alembic Config object
+# Alembic Config object, provides access to .ini values
 config = context.config
 
-# Logging config (optional)
+# If you use logging via alembic.ini
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Set DB URL from .env (via pydantic Settings)
-config.set_main_option("sqlalchemy.url", settings.database_url)
-
+# Tell Alembic what metadata to scan for autogenerate
 target_metadata = Base.metadata
 
 
+def _alembic_config_with_url() -> Dict[str, Any]:
+    """Prepare a config dict for async engine using env DATABASE_URL."""
+    db_url = os.getenv("DATABASE_URL", settings.DATABASE_URL)
+    cfg: Dict[str, Any] = config.get_section(config.config_ini_section) or {}
+    cfg["sqlalchemy.url"] = db_url
+    return cfg
+
+
 def run_migrations_offline() -> None:
-    """Run migrations in 'offline' mode."""
-    url = config.get_main_option("sqlalchemy.url")
+    """Run migrations in 'offline' mode (no DB connection)."""
+    url = os.getenv("DATABASE_URL", settings.DATABASE_URL)
     context.configure(
         url=url,
         target_metadata=target_metadata,
         literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        compare_server_default=True,
     )
+
     with context.begin_transaction():
         context.run_migrations()
 
 
-def do_run_migrations(connection: Connection) -> None:
-    context.configure(connection=connection, target_metadata=target_metadata)
+def do_run_migrations(connection) -> None:
+    """Synchronous body called under both async/online and offline runs."""
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        compare_server_default=True,
+    )
     with context.begin_transaction():
         context.run_migrations()
 
 
 async def run_async_migrations() -> None:
-    connectable = async_engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+    cfg = _alembic_config_with_url()
+    connectable: AsyncEngine = async_engine_from_config(cfg, prefix="sqlalchemy.")
     async with connectable.connect() as connection:
         await connection.run_sync(do_run_migrations)
     await connectable.dispose()
 
 
 def run_migrations_online() -> None:
+    """Run migrations in 'online' mode using async engine."""
     asyncio.run(run_async_migrations())
 
 
+# Entry point used by alembic
 if context.is_offline_mode():
     run_migrations_offline()
 else:

--- a/alembic/versions/df1230780a85_cards_signals_trades_daily_mv.py
+++ b/alembic/versions/df1230780a85_cards_signals_trades_daily_mv.py
@@ -1,0 +1,100 @@
+# mypy: ignore-errors
+"""cards + signals + trades_daily MV
+
+Revision ID: cards_signals_mv_0001
+Revises: 336346fb1797
+Create Date: 2025-08-23
+
+"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers
+revision: str = "cards_signals_mv_0001"
+down_revision: Union[str, Sequence[str], None] = "336346fb1797"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- cards ---
+    op.create_table(
+        "cards",
+        sa.Column("card_key", sa.String(128), primary_key=True),
+        sa.Column("name", sa.String(128), nullable=False),
+        sa.Column("set_code", sa.String(64), nullable=True),
+        sa.Column("set_name", sa.String(128), nullable=True),
+        sa.Column("rarity", sa.String(64), nullable=True),
+        sa.Column("rarity_bucket", sa.String(32), nullable=True),
+        sa.Column("character", sa.String(64), nullable=True),
+        sa.Column("art_type", sa.String(32), nullable=True),  # e.g. 'alt', 'promo'
+        sa.Column("language", sa.String(16), nullable=True, server_default="EN"),
+        sa.Column("release_date", sa.Date(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()")
+        ),
+    )
+    op.create_index("ix_cards_character", "cards", ["character"])
+    op.create_index("ix_cards_rarity_bucket", "cards", ["rarity_bucket"])
+
+    # --- signals ---
+    op.create_table(
+        "signals",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "asof_ts",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("card_key", sa.String(128), nullable=False),
+        sa.Column("horizon_days", sa.Integer(), nullable=False, server_default="90"),
+        sa.Column("action", sa.String(8), nullable=False),  # BUY/HOLD/SELL
+        sa.Column("conviction", sa.Float(), nullable=False),  # 0-100
+        sa.Column(
+            "expected_return", sa.Float(), nullable=False
+        ),  # fractional (e.g. 0.05)
+        sa.Column("risk", sa.Float(), nullable=False),  # fractional stdev
+        sa.Column("utility", sa.Float(), nullable=False),
+        sa.Column("model_version", sa.String(64), nullable=False),
+        sa.Column("features_json", sa.Text(), nullable=True),  # serialized features
+        sa.ForeignKeyConstraint(["card_key"], ["cards.card_key"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_signals_card_key_ts", "signals", ["card_key", "asof_ts"])
+
+    # --- trades_daily materialized view ---
+    # NOTE: Alembic runs inside a transaction; avoid CONCURRENTLY.
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS trades_daily AS
+        SELECT
+            card_key,
+            date(timestamp) AS day,
+            COUNT(*)                   AS trade_count,
+            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY price) AS median_price,
+            AVG(price)                 AS mean_price,
+            MAX(timestamp)             AS last_ts
+        FROM trades
+        GROUP BY card_key, day;
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ux_trades_daily_ck_day ON trades_daily(card_key, day);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_trades_daily_ck_day ON trades_daily(card_key, day);"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS trades_daily;")
+    op.drop_index("ix_signals_card_key_ts", table_name="signals")
+    op.drop_table("signals")
+    op.drop_index("ix_cards_rarity_bucket", table_name="cards")
+    op.drop_index("ix_cards_character", table_name="cards")
+    op.drop_table("cards")

--- a/alembic/versions/fdcbe190a7e3_add_features_jsonb_to_signals.py
+++ b/alembic/versions/fdcbe190a7e3_add_features_jsonb_to_signals.py
@@ -1,0 +1,32 @@
+# mypy: ignore-errors
+"""add features JSONB to signals
+
+Revision ID: fdcbe190a7e3
+Revises: cards_signals_mv_0001
+Create Date: 2025-08-23 19:36:33.949386
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "fdcbe190a7e3"
+down_revision: Union[str, Sequence[str], None] = "cards_signals_mv_0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema: add signals.features as JSONB (nullable)."""
+    op.add_column(
+        "signals",
+        sa.Column("features", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema: drop signals.features."""
+    op.drop_column("signals", "features")

--- a/src/pkmn_factors/config.py
+++ b/src/pkmn_factors/config.py
@@ -1,18 +1,33 @@
-from pydantic_settings import BaseSettings
-from pydantic import Field
+# src/pkmn_factors/config.py
+from __future__ import annotations
+
+from functools import lru_cache
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    env: str = Field(default="dev", alias="ENV")
-    log_level: str = Field(default="INFO", alias="LOG_LEVEL")
-    database_url: str = Field(
-        default="postgresql+asyncpg://postgres:postgres@localhost:5432/pkmn",
-        alias="DATABASE_URL",
+    # General
+    ENV: str = "dev"
+    LOG_LEVEL: str = "INFO"
+
+    # Database (async SQLAlchemy URL for Postgres/Timescale via asyncpg)
+    # If you run docker-compose from this repo, localhost:5432 is correct.
+    DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/pkmn"
+
+    # Pydantic Settings config: load from .env if present
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
     )
 
-    class Config:
-        env_file = ".env"
-        extra = "ignore"
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Singleton Settings instance (cached)."""
+    return Settings()
 
 
-settings = Settings()
+# Convenient module-level instance
+settings = get_settings()

--- a/src/pkmn_factors/factors/features.py
+++ b/src/pkmn_factors/factors/features.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class PriceFeatures:
+    ret_7: float
+    ret_30: float
+    risk: float
+    drawdown_30: float
+    value_z: float
+    liq_7: float
+    recency_days: float
+
+
+def _safe_pct_change(s: pd.Series, periods: int) -> float:
+    """Return percentage change over `periods`, robust to short or NaN series."""
+    try:
+        if len(s) <= periods or s.dropna().empty:
+            return float("nan")
+        end = s.iloc[-1]
+        start = s.iloc[-periods - 1]
+        if pd.isna(start) or start == 0:
+            return float("nan")
+        return float(end / start - 1.0)
+    except Exception:
+        return float("nan")
+
+
+def _rolling_vol(s: pd.Series, window: int) -> float:
+    try:
+        r = s.pct_change().dropna()
+        if r.empty:
+            return float("nan")
+        return float(r.tail(window).std(ddof=0))
+    except Exception:
+        return float("nan")
+
+
+def _max_drawdown(s: pd.Series, window: int) -> float:
+    """Max drawdown over a rolling window (as positive fraction)."""
+    try:
+        w = s.tail(window).astype(float)
+        if w.empty:
+            return float("nan")
+        roll_max = w.cummax()
+        dd = (w / roll_max) - 1.0
+        return float(abs(dd.min()))
+    except Exception:
+        return float("nan")
+
+
+def from_prices(df: pd.DataFrame) -> PriceFeatures:
+    """
+    Build baseline features from a price series dataframe with a 'price' column.
+    Expects df.index to be datetime-like and increasing.
+    """
+    if "price" not in df.columns:
+        raise ValueError("prices dataframe must contain a 'price' column")
+
+    series = df["price"].astype(float)
+
+    ret_7 = _safe_pct_change(series, 7)
+    ret_30 = _safe_pct_change(series, 30)
+    risk = _rolling_vol(series, 30)
+    drawdown_30 = _max_drawdown(series, 30)
+
+    # Value vs 30-day mean as a simple z-score proxy (mean-only, no variance normalization)
+    try:
+        ma30 = (
+            float(series.tail(30).mean()) if not series.tail(30).empty else float("nan")
+        )
+        value_z = (
+            float(series.iloc[-1] / ma30 - 1.0)
+            if ma30 and not np.isnan(ma30)
+            else float("nan")
+        )
+    except Exception:
+        value_z = float("nan")
+
+    # Liquidity proxy: number of observations in last 7 days
+    try:
+        liq_7 = float(series.last("7D").shape[0]) if not series.empty else 0.0
+    except Exception:
+        liq_7 = 0.0
+
+    # Recency of last trade in days (negative if last timestamp is in the future)
+    try:
+        ts = pd.to_datetime(series.index)
+        recency_days = float(
+            (pd.Timestamp.utcnow(tz="UTC") - ts.max()).total_seconds() / 86400.0
+        )
+    except Exception:
+        recency_days = float("nan")
+
+    return PriceFeatures(
+        ret_7=ret_7,
+        ret_30=ret_30,
+        risk=risk,
+        drawdown_30=drawdown_30,
+        value_z=value_z,
+        liq_7=liq_7,
+        recency_days=recency_days,
+    )
+
+
+def to_json(feats: PriceFeatures) -> Dict[str, float]:
+    return {
+        "ret_7": feats.ret_7,
+        "ret_30": feats.ret_30,
+        "risk": feats.risk,
+        "drawdown_30": feats.drawdown_30,
+        "value_z": feats.value_z,
+        "liq_7": feats.liq_7,
+        "recency_days": feats.recency_days,
+    }

--- a/src/pkmn_factors/models/bhs_baseline.py
+++ b/src/pkmn_factors/models/bhs_baseline.py
@@ -1,0 +1,222 @@
+# mypy: disable-error-code=attr-defined
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from pkmn_factors.config import settings
+from pkmn_factors.db.models import Trade, Signal
+
+# -----------------------------------------------------------------------------
+# Config for the baseline
+# -----------------------------------------------------------------------------
+
+HORIZON_DAYS = 90
+MODEL_VERSION = "1"  # VARCHAR in DB, so keep it as a string
+
+# -----------------------------------------------------------------------------
+# Small helpers
+# -----------------------------------------------------------------------------
+
+
+def _pct_change(series: pd.Series, periods: int) -> float:
+    """Return percentage change over `periods` days."""
+    if len(series) < periods + 1:
+        return np.nan
+    return float(series.iloc[-1] / series.iloc[-(periods + 1)] - 1.0)
+
+
+def _drawdown(series: pd.Series, window: int) -> float:
+    """Max drawdown over a trailing window (negative number)."""
+    if series.empty:
+        return np.nan
+    roll_max = series.rolling(window=window, min_periods=1).max()
+    dd = series / roll_max - 1.0
+    return float(dd.tail(window).min())
+
+
+# -----------------------------------------------------------------------------
+# Decision container
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class Decision:
+    action: str  # "BUY" | "HOLD" | "SELL"
+    conviction: float
+    expected_return: float
+    risk: float
+    utility: float
+    features: Dict[str, Any]
+
+
+# -----------------------------------------------------------------------------
+# Core logic
+# -----------------------------------------------------------------------------
+
+
+async def _load_trades(session: AsyncSession, card_key: str) -> pd.DataFrame:
+    """Fetch trades for one card and coerce to float prices & UTC index."""
+    q = (
+        select(Trade.timestamp, Trade.price)
+        .where(Trade.card_key == card_key)
+        .order_by(Trade.timestamp)
+    )
+    rows = (await session.execute(q)).all()
+    if not rows:
+        return pd.DataFrame(columns=["timestamp", "price"])
+
+    df = pd.DataFrame(rows, columns=["timestamp", "price"])
+    # Make timestamps tz-aware UTC
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+
+    # *** Important: prices come back as Decimal -> coerce to float ***
+    df["price"] = pd.to_numeric(df["price"], errors="coerce").astype(float)
+
+    # Drop any nulls just in case and index by time
+    df = df.dropna(subset=["price"]).set_index("timestamp").sort_index()
+    return df
+
+
+def _features_from_prices(prices: pd.Series) -> Dict[str, Any]:
+    """Compute simple features out of a price series."""
+    # Daily last price to make horizons consistent
+    daily = prices.resample("1D").last().ffill()
+
+    ret_7 = _pct_change(daily, 7)
+    ret_30 = _pct_change(daily, 30)
+
+    # Risk proxy: 30-day std of daily returns
+    daily_ret = daily.pct_change().dropna()
+    risk = float(daily_ret.tail(30).std()) if not daily_ret.empty else np.nan
+
+    # Trailing drawdown
+    dd_30 = _drawdown(daily, 30)
+
+    # "Value" vs 30-day moving average (z-score)
+    if len(daily) >= 30:
+        ma = daily.rolling(30).mean()
+        std = daily.rolling(30).std()
+        denom = std.iloc[-1]
+        value_z = (
+            float((daily.iloc[-1] - ma.iloc[-1]) / denom)
+            if denom and not np.isnan(denom)
+            else np.nan
+        )
+    else:
+        value_z = np.nan
+
+    # Liquidity proxy: count of raw trades in last 7 days
+    liq_7 = int(prices.last("7D").shape[0]) if not prices.empty else 0
+
+    # Recency (days since last raw trade)
+    now_utc = pd.Timestamp.now(tz="UTC")
+    recency_days = (
+        float((now_utc - prices.index[-1]) / timedelta(days=1))
+        if not prices.empty
+        else np.nan
+    )
+
+    return {
+        "ret_7": ret_7,
+        "ret_30": ret_30,
+        "risk": risk,
+        "drawdown_30": dd_30,
+        "value_z": value_z,
+        "liq_7": liq_7,
+        "recency_days": recency_days,
+    }
+
+
+def _score_to_decision(feats: Dict[str, Any]) -> Decision:
+    """Toy Buy/Hold/Sell rule using expected return and risk."""
+    exp_ret = feats.get("ret_30")
+    if exp_ret is None or np.isnan(exp_ret):
+        exp_ret = feats.get("ret_7")
+    if exp_ret is None or np.isnan(exp_ret):
+        exp_ret = 0.0
+
+    risk = feats.get("risk")
+    if risk is None or np.isnan(risk):
+        risk = 0.0
+
+    # Simple utility function
+    utility = float(exp_ret - 4.0 * risk)
+
+    # Map to action
+    if utility > 0.02:
+        action = "BUY"
+    elif utility < -0.02:
+        action = "SELL"
+    else:
+        action = "HOLD"
+
+    # Conviction is a squashed utility to 0..1
+    conv = 1 / (1 + np.exp(-utility * 50))
+
+    return Decision(
+        action=action,
+        conviction=float(conv),
+        expected_return=float(exp_ret),
+        risk=float(risk),
+        utility=float(utility),
+        features=feats,
+    )
+
+
+async def run(card_key: str) -> Decision:
+    engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with Session() as session:
+        df = await _load_trades(session, card_key)
+        if df.empty:
+            dec = Decision("HOLD", 0.0, 0.0, 0.0, 0.0, {})
+        else:
+            feats = _features_from_prices(df["price"])
+            dec = _score_to_decision(feats)
+
+        await _write_signal(session, card_key, dec)
+        return dec
+
+
+async def _write_signal(session: AsyncSession, card_key: str, dec: Decision) -> None:
+    row = Signal(
+        card_key=card_key,
+        horizon_days=HORIZON_DAYS,
+        action=dec.action,
+        conviction=dec.conviction,
+        expected_return=dec.expected_return,
+        risk=dec.risk,
+        utility=dec.utility,
+        model_version=str(MODEL_VERSION),  # keep as string
+        features=dec.features,  # JSONB
+    )
+    session.add(row)
+    await session.commit()
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--card-key", required=True)
+    args = p.parse_args()
+
+    dec = asyncio.run(run(args.card_key))
+    print(dec)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pkmn_factors/models/bhs_baseline_v2.py
+++ b/src/pkmn_factors/models/bhs_baseline_v2.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from pkmn_factors.config import settings
+from pkmn_factors.db.models import Trade, Signal
+from pkmn_factors.factors.features import build_features, Features
+
+MODEL_VERSION = "bhs_baseline_v2"
+DEFAULT_HORIZON_DAYS = 90
+
+WIN_RETURN = 30
+WIN_RISK = 30
+WIN_REG = 30
+LAMBDA_RISK = 4.0
+
+
+@dataclass
+class Decision:
+    action: str
+    conviction: float
+    expected_return: float
+    risk: float
+    utility: float
+    features: Dict[str, Any]
+
+
+async def _load_trades(session: AsyncSession, card_key: str) -> pd.DataFrame:
+    q = (
+        select(Trade.timestamp, Trade.price)
+        .where(Trade.card_key == card_key)
+        .order_by(Trade.timestamp)
+    )
+    rows = (await session.execute(q)).all()
+    if not rows:
+        return pd.DataFrame(columns=["timestamp", "price"])
+
+    df = pd.DataFrame(rows, columns=["timestamp", "price"])
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    df["price"] = pd.to_numeric(df["price"], errors="coerce").astype(float)
+    df = df.dropna(subset=["price"]).sort_values("timestamp").set_index("timestamp")
+    return df
+
+
+def _rolling_expected_return(daily: pd.Series, win: int = WIN_RETURN) -> float:
+    if daily.size < 2:
+        return float("nan")
+    r = daily.pct_change().dropna()
+    if r.empty:
+        return float("nan")
+    r_tail = r.tail(win)
+    return float(r_tail.mean()) if not r_tail.empty else float("nan")
+
+
+def _rolling_risk(daily: pd.Series, win: int = WIN_RISK) -> float:
+    r = daily.pct_change().dropna().tail(win)
+    return float(r.std(ddof=1)) if not r.empty else float("nan")
+
+
+def _trend_slope_logprice(daily: pd.Series, win: int = WIN_REG) -> float:
+    s = daily.dropna().tail(win)
+    if s.size < 2:
+        return float("nan")
+    y = np.log(np.asarray(s.values, dtype=float))  # ensure ndarray[float]
+    x = np.arange(y.size, dtype=float)
+    try:
+        slope = float(np.polyfit(x, y, 1)[0])
+        return slope
+    except Exception:
+        return float("nan")
+
+
+def _prob_buy_from_utility(
+    expected_return: float, risk: float, lam: float = LAMBDA_RISK
+) -> Tuple[float, float]:
+    if np.isnan(expected_return):
+        expected_return = 0.0
+    if np.isnan(risk):
+        risk = 0.0
+    utility = float(expected_return - lam * risk)
+    temp = 50.0
+    prob = 1.0 / (1.0 + np.exp(-utility * temp))
+    return float(prob), float(utility)
+
+
+def _action_from_utility(
+    utility: float, buy_thresh: float = 0.02, sell_thresh: float = -0.02
+) -> str:
+    if utility > buy_thresh:
+        return "BUY"
+    if utility < sell_thresh:
+        return "SELL"
+    return "HOLD"
+
+
+def _expected_return_blend(daily: pd.Series) -> float:
+    mu = _rolling_expected_return(daily, WIN_RETURN)
+    slope = _trend_slope_logprice(daily, WIN_REG)
+    if np.isnan(mu) and np.isnan(slope):
+        return float("nan")
+    if np.isnan(mu):
+        return slope
+    if np.isnan(slope):
+        return mu
+    return float(0.5 * mu + 0.5 * slope)
+
+
+def _compute_signal_from_prices(raw: pd.DataFrame) -> Tuple[Decision, Features]:
+    df_reset = raw.reset_index()
+    feats_struct = build_features(df_reset)
+
+    daily = raw["price"].resample("1D").last().ffill()
+
+    exp_ret = _expected_return_blend(daily)
+    risk = _rolling_risk(daily)
+    prob_buy, utility = _prob_buy_from_utility(exp_ret, risk, LAMBDA_RISK)
+    action = _action_from_utility(utility)
+
+    dec = Decision(
+        action=action,
+        conviction=float(prob_buy),
+        expected_return=float(exp_ret if not np.isnan(exp_ret) else 0.0),
+        risk=float(risk if not np.isnan(risk) else 0.0),
+        utility=float(utility),
+        features=feats_struct.as_json(),
+    )
+    return dec, feats_struct
+
+
+async def _write_signal(
+    session: AsyncSession, card_key: str, dec: Decision, horizon_days: int
+) -> None:
+    row = Signal(
+        card_key=card_key,
+        horizon_days=horizon_days,
+        action=dec.action,
+        conviction=dec.conviction,
+        expected_return=dec.expected_return,
+        risk=dec.risk,
+        utility=dec.utility,
+        model_version=MODEL_VERSION,
+        features=dec.features,
+    )
+    session.add(row)
+    await session.commit()
+
+
+async def run(card_key: str, horizon_days: int = DEFAULT_HORIZON_DAYS) -> Decision:
+    engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with Session() as session:
+        raw = await _load_trades(session, card_key)
+        if raw.empty:
+            empty = Decision("HOLD", 0.5, 0.0, 0.0, 0.0, {})
+            await _write_signal(session, card_key, empty, horizon_days)
+            return empty
+
+        dec, _ = _compute_signal_from_prices(raw)
+        await _write_signal(session, card_key, dec, horizon_days)
+        return dec
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--card-key", required=True)
+    p.add_argument("--horizon-days", type=int, default=DEFAULT_HORIZON_DAYS)
+    args = p.parse_args()
+
+    decision = asyncio.run(run(args.card_key, args.horizon_days))
+    print(decision)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pkmn_factors/ops/maintenance.py
+++ b/src/pkmn_factors/ops/maintenance.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from pkmn_factors.config import settings
+
+
+def create_engine(
+    url: str | None = None, echo: bool = False, pool_pre_ping: bool = True
+) -> AsyncEngine:
+    return create_async_engine(
+        url or settings.DATABASE_URL, echo=echo, pool_pre_ping=pool_pre_ping
+    )
+
+
+async def _exec_many(engine: AsyncEngine, stmts: Sequence[sa.sql.Executable]) -> None:
+    async with engine.begin() as conn:
+        for s in stmts:
+            await conn.execute(s)
+
+
+async def refresh_trades_daily() -> None:
+    engine = create_engine()
+    await _exec_many(
+        engine, [sa.text("REFRESH MATERIALIZED VIEW CONCURRENTLY trades_daily")]
+    )
+
+
+async def seed_cards() -> None:
+    engine = create_engine()
+    stmt = sa.text(
+        """
+        INSERT INTO cards (card_key, name, set_code, rarity)
+        VALUES (:card_key, :name, :set_code, :rarity)
+        ON CONFLICT (card_key) DO NOTHING
+        """
+    )
+    params = [
+        {
+            "card_key": "mew-ex-053-svp-2023",
+            "name": "Mew ex #053",
+            "set_code": "SVP",
+            "rarity": "Promo",
+        },
+    ]
+    async with engine.begin() as conn:
+        for p in params:
+            await conn.execute(stmt, p)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seed-demo", action="store_true")
+    ap.add_argument("--refresh-mv", action="store_true")
+    args = ap.parse_args()
+
+    if args.seed_demo:
+        asyncio.run(seed_cards())
+    if args.refresh_mv:
+        asyncio.run(refresh_trades_daily())


### PR DESCRIPTION
### What’s changed
- Fixed persistence of backtest metrics into the `metrics` table.
- JSONB params (e.g., notes, filters, counts) are now bound correctly instead of raising asyncpg encoding errors.
- Ensures backtest runs can store metadata alongside numeric metrics.

### Why
Previously, persisting metrics failed with: asyncpg.exceptions.DataError: invalid input for query argument $15: {'notes': ...} ('dict' object has no attribute 'encode')

because a raw Python dict was being passed. This fix converts it to JSONB-compatible format.

### Testing
- Ran `uv run python -m pkmn_factors.eval.backtest ... --persist`.
- Verified row written successfully in `metrics` table.